### PR TITLE
Reduce time complexity of BFS from O(n^2) to O(n)

### DIFF
--- a/001 Search Algorithms Codes/bfs.py
+++ b/001 Search Algorithms Codes/bfs.py
@@ -1,4 +1,5 @@
 import copy
+from collections import deque
 
 goal = [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
@@ -31,12 +32,12 @@ def goal_test(list):
 
 def bfs(board):
     start = Node(board)
-    queue = []
+    queue = deque()
     queue.append(start)
 
     cost = 0
-    while True:
-        next = queue.pop(0)
+    while queue:
+        next = queue.popleft()
         print(next.board)
         children = next.expand()
         cost += 1


### PR DESCRIPTION
As all of us know, time complexity of popping first element of list is O(n). So, using list for BFS will make time complexity O(n^2).

Using collections.deque (that has time complexity of O(1) for both appending and popping) reduces the overall time complexity to O(n).